### PR TITLE
Initialize finance charts after creation

### DIFF
--- a/app/templates/finance.html
+++ b/app/templates/finance.html
@@ -1018,6 +1018,8 @@
                 });
 
                 this.chartsInitialized = true;
+                // Fetch initial data for the newly created charts
+                this.updateCharts();
             },
 
             updateCharts() {


### PR DESCRIPTION
## Summary
- After constructing Chart.js instances in `initCharts`, immediately call `updateCharts` so revenue and expense charts fetch and display data on page load

## Testing
- `pytest tests/test_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce38a7978832b919cd4f20ade5e59