### PR TITLE
Fix expense chart legend generation to render charts

### DIFF
--- a/app/templates/finance.html
+++ b/app/templates/finance.html
@@ -1008,23 +1008,11 @@
                                     padding: 20,
                                     generateLabels: (chart) => {
                                         const defaultLabels = (Chart.defaults.plugins.legend.labels.generateLabels && Chart.defaults.plugins.legend.labels.generateLabels(chart)) || [];
-                                        return defaultLabels.map(l => {
-                                            const labelText = l && l.text ? l.text : '';
-                                            // Build a new object, omitting 'disabled'
-                                            return {
-                                                text: l && l.text ? l.text : '',
-                                                datasetIndex: l && typeof l.datasetIndex !== 'undefined' ? l.datasetIndex : undefined,
-                                                index: l && typeof l.index !== 'undefined' ? l.index : undefined,
-                                                fillStyle: l && l.fillStyle ? l.fillStyle : '#9CA3AF',
-                                                strokeStyle: l && l.strokeStyle ? l.strokeStyle : undefined,
-                                                lineWidth: l && l.lineWidth ? l.lineWidth : undefined,
-                                                hidden: l && typeof l.hidden !== 'undefined' ? l.hidden : false,
-                                                pointStyle: l && l.pointStyle ? l.pointStyle : undefined,
-                                                rotation: l && l.rotation ? l.rotation : undefined,
-                                                ariaLabel: `Catégorie ${labelText}` + ((this.searchTerm === labelText && this.filterType === 'expense') ? ' (filtrée)' : ''),
-                                                fontColor: (this.searchTerm === labelText && this.filterType === 'expense') ? '#1d4ed8' : '#374151',
-                                            };
-                                        });
+                                        return defaultLabels.map(l => ({
+                                            ...l,
+                                            ariaLabel: `Catégorie ${l.text}` + ((this.searchTerm === l.text && this.filterType === 'expense') ? ' (filtrée)' : ''),
+                                            fontColor: (this.searchTerm === l.text && this.filterType === 'expense') ? '#1d4ed8' : '#374151',
+                                        }));
                                     }
                                 },
                                 onClick: (e, legendItem, legend) => {


### PR DESCRIPTION
## Summary
- Preserve Chart.js legend item properties by mapping default labels with spread so plugins no longer access undefined items
- Ensures revenue and expense charts render without `disabled` property errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cf0dcec88832bbbd0fd0e4581fd8a