### PR TITLE
Enhance report exports and sales chart rendering

### DIFF
--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -505,12 +505,29 @@ def export_report(report_type):
                 WHERE DATE(expense_date) BETWEEN ? AND ?
                 ORDER BY expense_date DESC
             ''', (start_date, end_date))
-            headers = ['Date', 'Catégorie', 'Sous-catégorie', 'Description', 
+            headers = ['Date', 'Catégorie', 'Sous-catégorie', 'Description',
                       'Montant', 'Reçu', 'Créé par']
-            
+
+        elif report_type == 'customers':
+            cursor.execute('''
+                SELECT id, name, phone, email, address, created_at
+                FROM customers
+                WHERE is_active = 1
+                ORDER BY name
+            ''')
+            headers = ['ID', 'Nom', 'Téléphone', 'Email', 'Adresse', 'Créé le']
+
+        elif report_type == 'ai_insights':
+            cursor.execute('''
+                SELECT prediction_type, product_id, prediction_data, confidence_score, prediction_date
+                FROM ai_predictions
+                ORDER BY prediction_date DESC
+            ''')
+            headers = ['Type', 'ID Produit', 'Données', 'Confiance', 'Date']
+
         elif report_type == 'debts':
             cursor.execute('''
-                SELECT 'Client' as type, client_name as name, total_amount, 
+                SELECT 'Client' as type, client_name as name, total_amount,
                        paid_amount, remaining_amount, due_date, status
                 FROM client_debts
                 UNION ALL

--- a/app/templates/reports.html
+++ b/app/templates/reports.html
@@ -195,7 +195,7 @@
                             </tr>
                         </thead>
                         <tbody class="bg-white divide-y divide-gray-200">
-                            <template x-for="product in reportData.sales.top_products" :key="product.id">
+                            <template x-for="(product, idx) in reportData.sales.top_products" :key="idx">
                                 <tr>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900" x-text="product.name || '-' "></td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" x-text="product.quantity ?? 0"></td>
@@ -405,26 +405,26 @@
                     this.filters.start_date = now.toISOString().split('T')[0];
                     this.filters.end_date = now.toISOString().split('T')[0];
                     
-                    this.loadReportData();
-                    if (this.activeReport === 'activities') this.loadActivities();
-                    if (this.activeReport === 'ai_insights') this.loadAI();
-                    this.$nextTick(() => {
-                        this.initCharts();
+                    this.loadReportData().then(() => {
+                        if (this.activeReport === 'sales') {
+                            this.initCharts();
+                        }
+                        if (this.activeReport === 'activities') this.loadActivities();
+                        if (this.activeReport === 'ai_insights') this.loadAI();
                     });
                 },
-                
+
                 setActiveReport(type) {
     if (this.salesChart && typeof this.salesChart.destroy === 'function') {
         this.salesChart.destroy();
         this.salesChart = null;
     }
     this.activeReport = type;
-    this.loadReportData();
-    if (type === 'sales') {
-        this.$nextTick(() => {
+    this.loadReportData().then(() => {
+        if (type === 'sales') {
             this.initCharts();
-        });
-    }
+        }
+    });
 },
                 
                 loadReportData() {
@@ -541,7 +541,7 @@
                         );
                     }
 
-                    Promise.all(tasks).finally(() => {
+                    return Promise.all(tasks).finally(() => {
                         if (this.activeReport === 'activities') this.loadActivities();
                         if (this.activeReport === 'ai_insights') this.loadAI();
                     });
@@ -723,12 +723,24 @@
                         end_date: this.filters.end_date || ''
                     }).toString();
                     let endpoint;
-                    if (this.activeReport === 'sales') {
-                        endpoint = '/api/reports/export/sales';
-                    } else if (this.activeReport === 'inventory') {
-                        endpoint = '/api/reports/export/products';
-                    } else {
-                        endpoint = '/api/reports/export/expenses';
+                    switch (this.activeReport) {
+                        case 'sales':
+                            endpoint = '/api/reports/export/sales';
+                            break;
+                        case 'inventory':
+                            endpoint = '/api/reports/export/products';
+                            break;
+                        case 'financial':
+                            endpoint = '/api/reports/export/expenses';
+                            break;
+                        case 'customers':
+                            endpoint = '/api/reports/export/customers';
+                            break;
+                        case 'ai_insights':
+                            endpoint = '/api/reports/export/ai_insights';
+                            break;
+                        default:
+                            endpoint = '/api/reports/export/sales';
                     }
                     try {
                         window.open(`${endpoint}?${params}`, '_blank');


### PR DESCRIPTION
## Summary
- Ensure sales report table iterates all products reliably
- Initialize charts after report data loads and map export endpoints for all report types
- Extend API export handler to support customers and AI insight reports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d1d64e534832b897d9dc52064a859